### PR TITLE
Fix an error

### DIFF
--- a/ocu/list_events.py
+++ b/ocu/list_events.py
@@ -28,7 +28,7 @@ def get_event_blobs():
 def get_events():
 
     event_blobs = get_event_blobs()
-    return [Event(event_blob) for event_blob in event_blobs]
+    return [Event(event_blob) for event_blob in event_blobs if '\n' in event_blob]
 
 
 # Read the given ICS file path and return the Event object corresponding to


### PR DESCRIPTION
I ran into an issue with google calendar introducing a 'ghost' event with no further details. 

This caused the following error:

```
[11:42:05.471] ERROR: Open Conference URL[Script Filter] Code 1: Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/timo.roest/alfred-workflows/Alfred.alfredpreferences/workflows/user.workflow.06AAEE19-D658-4E0D-84A2-78F4416C6EEA/ocu/list_events.py", line 115, in <module>
    main()
  File "/Users/timo.roest/alfred-workflows/Alfred.alfredpreferences/workflows/user.workflow.06AAEE19-D658-4E0D-84A2-78F4416C6EEA/ocu/list_events.py", line 79, in main
    all_events = [event for event in get_events() if event.conference_url]
  File "/Users/timo.roest/alfred-workflows/Alfred.alfredpreferences/workflows/user.workflow.06AAEE19-D658-4E0D-84A2-78F4416C6EEA/ocu/list_events.py", line 31, in get_events
    return [Event(event_blob) for event_blob in event_blobs]
  File "ocu/event.py", line 17, in __init__
    self.title = self.parse_title()
  File "ocu/event.py", line 31, in parse_title
    return re.search(r'^(.*?)\n', self.blob).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

The event blob it generated looked like this:
`['Ash Wednesday\n    2021-02-17', '2021-02-17',]`

The second one generated an error as it did not match the regex. 
This is just a quick fix that ensures the events can parse correctly skipping events that don't have a newline `\n` character in it.

A better solution might be to modify the regex for parsing; or it might have been a quick bug in google calendar. But it could be worth checking out!